### PR TITLE
Fix StethoInterceptor setup for OkHttpClient

### DIFF
--- a/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModelImpl.java
+++ b/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModelImpl.java
@@ -98,7 +98,7 @@ public class DeveloperSettingsModelImpl implements DeveloperSettingModel {
         if (stethoAlreadyEnabled.compareAndSet(false, true)) {
             if (isStethoEnabled()) {
                 Stetho.initializeWithDefaults(qualityMattersApp);
-                okHttpClient.interceptors().add(new StethoInterceptor());
+                okHttpClient.networkInterceptors().add(new StethoInterceptor());
             }
         }
 


### PR DESCRIPTION
Using `okHttpClient.interceptors()` for `StethoInterceptor` could lead to NPE in some cases. [1, 2]
Correct way to setup it is using `networkInterceptors()` method of `OkHttpClient`.[3]

[1] https://github.com/facebook/stetho/issues/267
[2] https://github.com/facebook/stetho/issues/223
[3] https://github.com/facebook/stetho 