### PR TITLE
Gradle Wrapper 2.11

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 07 11:39:05 CET 2016
+#Thu Feb 18 15:17:04 EST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-bin.zip


### PR DESCRIPTION
@vanniktech PTAL

Looks like neither `gradle-wrapper.jar` nor `cli` files were changed in compare to 2.10