### PR TITLE
Provide Application class instead of QualityMattersApp

### DIFF
--- a/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModelImpl.java
+++ b/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModelImpl.java
@@ -1,10 +1,10 @@
 package com.artemzin.qualitymatters.developer_settings;
 
+import android.app.Application;
 import android.support.annotation.NonNull;
 import android.util.DisplayMetrics;
 
 import com.artemzin.qualitymatters.BuildConfig;
-import com.artemzin.qualitymatters.QualityMattersApp;
 import com.codemonkeylabs.fpslibrary.TinyDancer;
 import com.facebook.stetho.Stetho;
 
@@ -20,7 +20,7 @@ import static android.view.Gravity.TOP;
 public class DeveloperSettingsModelImpl implements DeveloperSettingsModel {
 
     @NonNull
-    private final QualityMattersApp qualityMattersApp;
+    private final Application qualityMattersApp;
 
     @NonNull
     private final DeveloperSettings developerSettings;
@@ -43,7 +43,7 @@ public class DeveloperSettingsModelImpl implements DeveloperSettingsModel {
     @NonNull
     private AtomicBoolean tinyDancerDisplayed = new AtomicBoolean();
 
-    public DeveloperSettingsModelImpl(@NonNull QualityMattersApp qualityMattersApp,
+    public DeveloperSettingsModelImpl(@NonNull Application qualityMattersApp,
                                       @NonNull DeveloperSettings developerSettings,
                                       @NonNull HttpLoggingInterceptor httpLoggingInterceptor,
                                       @NonNull LeakCanaryProxy leakCanaryProxy,

--- a/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModule.java
+++ b/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModule.java
@@ -1,13 +1,12 @@
 package com.artemzin.qualitymatters.developer_settings;
 
+import android.app.Application;
 import android.support.annotation.NonNull;
 
-import com.artemzin.qualitymatters.QualityMattersApp;
 import com.artemzin.qualitymatters.models.AnalyticsModel;
 import com.artemzin.qualitymatters.ui.other.ViewModifier;
 import com.artemzin.qualitymatters.ui.presenters.DeveloperSettingsPresenter;
 import com.github.pedrovgs.lynx.LynxConfig;
-import okhttp3.logging.HttpLoggingInterceptor;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -15,6 +14,7 @@ import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
 import hu.supercluster.paperwork.Paperwork;
+import okhttp3.logging.HttpLoggingInterceptor;
 
 import static android.content.Context.MODE_PRIVATE;
 
@@ -40,21 +40,21 @@ public class DeveloperSettingsModule {
     @Provides
     @NonNull
     @Singleton
-    public DeveloperSettings provideDeveloperSettings(@NonNull QualityMattersApp qualityMattersApp) {
+    public DeveloperSettings provideDeveloperSettings(@NonNull Application qualityMattersApp) {
         return new DeveloperSettings(qualityMattersApp.getSharedPreferences("developer_settings", MODE_PRIVATE));
     }
 
     @Provides
     @NonNull
     @Singleton
-    public LeakCanaryProxy provideLeakCanaryProxy(@NonNull QualityMattersApp qualityMattersApp) {
+    public LeakCanaryProxy provideLeakCanaryProxy(@NonNull Application qualityMattersApp) {
         return new LeakCanaryProxyImpl(qualityMattersApp);
     }
 
     @Provides
     @NonNull
     @Singleton
-    public Paperwork providePaperwork(@NonNull QualityMattersApp qualityMattersApp) {
+    public Paperwork providePaperwork(@NonNull Application qualityMattersApp) {
         return new Paperwork(qualityMattersApp);
     }
 
@@ -62,7 +62,7 @@ public class DeveloperSettingsModule {
     @Provides
     @NonNull
     @Singleton
-    public DeveloperSettingsModelImpl provideDeveloperSettingsModelImpl(@NonNull QualityMattersApp qualityMattersApp,
+    public DeveloperSettingsModelImpl provideDeveloperSettingsModelImpl(@NonNull Application qualityMattersApp,
                                                                         @NonNull DeveloperSettings developerSettings,
                                                                         @NonNull HttpLoggingInterceptor httpLoggingInterceptor,
                                                                         @NonNull LeakCanaryProxy leakCanaryProxy,

--- a/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/LeakCanaryProxyImpl.java
+++ b/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/LeakCanaryProxyImpl.java
@@ -1,21 +1,21 @@
 package com.artemzin.qualitymatters.developer_settings;
 
+import android.app.Application;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.artemzin.qualitymatters.QualityMattersApp;
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
 
 public class LeakCanaryProxyImpl implements LeakCanaryProxy {
 
     @NonNull
-    private final QualityMattersApp qualityMattersApp;
+    private final Application qualityMattersApp;
 
     @Nullable
     private RefWatcher refWatcher;
 
-    public LeakCanaryProxyImpl(@NonNull QualityMattersApp qualityMattersApp) {
+    public LeakCanaryProxyImpl(@NonNull Application qualityMattersApp) {
         this.qualityMattersApp = qualityMattersApp;
     }
 

--- a/app/src/functionalTests/java/com/artemzin/qualitymatters/functional_tests/QualityMattersFunctionalTestApp.java
+++ b/app/src/functionalTests/java/com/artemzin/qualitymatters/functional_tests/QualityMattersFunctionalTestApp.java
@@ -1,5 +1,6 @@
 package com.artemzin.qualitymatters.functional_tests;
 
+import android.app.Application;
 import android.support.annotation.NonNull;
 
 import com.artemzin.qualitymatters.DaggerApplicationComponent;
@@ -18,7 +19,7 @@ public class QualityMattersFunctionalTestApp extends QualityMattersApp {
                 .modelsModule(new ModelsModule() {
                     @NonNull
                     @Override
-                    public AnalyticsModel provideAnalyticsModel(@NonNull QualityMattersApp app) {
+                    public AnalyticsModel provideAnalyticsModel(@NonNull Application app) {
                         // We don't need real analytics in Functional tests, but let's just log it instead!
                         return new AnalyticsModel() {
 

--- a/app/src/integrationTests/java/com/artemzin/qualitymatters/QualityMattersIntegrationTestApp.java
+++ b/app/src/integrationTests/java/com/artemzin/qualitymatters/QualityMattersIntegrationTestApp.java
@@ -1,5 +1,6 @@
 package com.artemzin.qualitymatters;
 
+import android.app.Application;
 import android.support.annotation.NonNull;
 
 import com.artemzin.qualitymatters.models.AnalyticsModel;
@@ -16,7 +17,7 @@ public class QualityMattersIntegrationTestApp extends QualityMattersApp {
                 .modelsModule(new ModelsModule() {
                     @NonNull
                     @Override
-                    public AnalyticsModel provideAnalyticsModel(@NonNull QualityMattersApp app) {
+                    public AnalyticsModel provideAnalyticsModel(@NonNull Application app) {
                         return mock(AnalyticsModel.class); // We don't need real analytics in integration tests.
                     }
                 });

--- a/app/src/main/java/com/artemzin/qualitymatters/ApplicationModule.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/ApplicationModule.java
@@ -1,5 +1,6 @@
 package com.artemzin.qualitymatters;
 
+import android.app.Application;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
@@ -21,14 +22,14 @@ public class ApplicationModule {
     public static final String MAIN_THREAD_HANDLER = "main_thread_handler";
 
     @NonNull
-    private final QualityMattersApp qualityMattersApp;
+    private final Application qualityMattersApp;
 
-    public ApplicationModule(@NonNull QualityMattersApp qualityMattersApp) {
+    public ApplicationModule(@NonNull Application qualityMattersApp) {
         this.qualityMattersApp = qualityMattersApp;
     }
 
     @Provides @NonNull @Singleton
-    public QualityMattersApp provideQualityMattersApp() {
+    public Application provideQualityMattersApp() {
         return qualityMattersApp;
     }
 
@@ -43,7 +44,7 @@ public class ApplicationModule {
     }
 
     @Provides @NonNull @Singleton
-    public Picasso providePicasso(@NonNull QualityMattersApp qualityMattersApp, @NonNull OkHttpClient okHttpClient) {
+    public Picasso providePicasso(@NonNull Application qualityMattersApp, @NonNull OkHttpClient okHttpClient) {
         return new Picasso.Builder(qualityMattersApp)
                 .downloader(new OkHttp3Downloader(okHttpClient))
                 .build();

--- a/app/src/main/java/com/artemzin/qualitymatters/models/ModelsModule.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/models/ModelsModule.java
@@ -1,8 +1,8 @@
 package com.artemzin.qualitymatters.models;
 
+import android.app.Application;
 import android.support.annotation.NonNull;
 
-import com.artemzin.qualitymatters.QualityMattersApp;
 import com.artemzin.qualitymatters.api.QualityMattersRestApi;
 import com.yandex.metrica.YandexMetrica;
 
@@ -15,7 +15,7 @@ import dagger.Provides;
 public class ModelsModule {
 
     @Provides @NonNull @Singleton
-    public AnalyticsModel provideAnalyticsModel(@NonNull QualityMattersApp app) {
+    public AnalyticsModel provideAnalyticsModel(@NonNull Application app) {
         return new YandexAppMetricaAnalytics(app);
     }
 
@@ -27,9 +27,9 @@ public class ModelsModule {
     static class YandexAppMetricaAnalytics implements AnalyticsModel {
 
         @NonNull
-        private final QualityMattersApp app;
+        private final Application app;
 
-        YandexAppMetricaAnalytics(@NonNull QualityMattersApp app) {
+        YandexAppMetricaAnalytics(@NonNull Application app) {
             this.app = app;
         }
 

--- a/app/src/unitTests/java/com/artemzin/qualitymatters/QualityMattersUnitTestApp.java
+++ b/app/src/unitTests/java/com/artemzin/qualitymatters/QualityMattersUnitTestApp.java
@@ -1,5 +1,6 @@
 package com.artemzin.qualitymatters;
 
+import android.app.Application;
 import android.support.annotation.NonNull;
 
 import com.artemzin.qualitymatters.models.AnalyticsModel;
@@ -16,7 +17,7 @@ public class QualityMattersUnitTestApp extends QualityMattersApp {
                 .modelsModule(new ModelsModule() {
                     @NonNull
                     @Override
-                    public AnalyticsModel provideAnalyticsModel(@NonNull QualityMattersApp app) {
+                    public AnalyticsModel provideAnalyticsModel(@NonNull Application app) {
                         return mock(AnalyticsModel.class); // We don't need real analytics in Unit tests.
                     }
                 });


### PR DESCRIPTION
Related to #78 and https://github.com/google/dagger/issues/328

Unfortunately, this does not remove warning from Dagger, but it makes design of modules a little bit better and easier to reuse in other projects.

Initially, I thought that it removed the warning because I did `assemble` without clean and annotation processing was skipped.