### PR TITLE
Test double call to DisposableSubscription.unsubscribe()

### DIFF
--- a/app/src/unitTests/java/com/artemzin/qualitymatters/other/DisposableSubscriptionTest.java
+++ b/app/src/unitTests/java/com/artemzin/qualitymatters/other/DisposableSubscriptionTest.java
@@ -38,4 +38,11 @@ public class DisposableSubscriptionTest {
         disposableSubscription.unsubscribe();
         verify(disposeAction).call();
     }
+
+    @Test
+    public void unsubscribeTwice_shouldCallDisposableActionOnce() {
+        disposableSubscription.unsubscribe();
+        disposableSubscription.unsubscribe();
+        verify(disposeAction).call();
+    }
 }


### PR DESCRIPTION
Previously we didn't cover case with second call to `unsubscribe()` in `DisposableSubscription`

![screen shot 2016-03-15 at 17 49 55](https://cloud.githubusercontent.com/assets/967132/13782009/71f3e4e4-ead6-11e5-8d65-e058f84c188c.png)

Now coverage of this class should be 100%.

@vanniktech PTAL 