### PR TITLE
Update AutoValue to 1.2-rc1, exclude its classes from the apk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,7 +121,10 @@ dependencies {
     compile libraries.retrofitRxJavaAdapter
     compile libraries.jacksonDataBind
 
-    compile libraries.autoValue
+    // Do not compile AutoValue dependencies to the app.
+    apt libraries.autoValue
+    // Make AutoValue annotation visible to the compiler.
+    provided libraries.autoValue
 
     compile libraries.supportAnnotations
     compile libraries.supportAppCompat

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,7 +23,7 @@ ext.versions = [
         okHttp                       : '3.2.0',
         retrofit                     : '2.0.0-beta4',
         jackson                      : '2.6.3',
-        autoValue                    : '1.1',
+        autoValue                    : '1.2-rc1',
         butterKnife                  : '7.0.1',
         picasso                      : '2.5.2',
         picassoOkHttpDownloader      : '1.0.2',


### PR DESCRIPTION
No changelog, but basically it now has extensions and better-shaded dependencies like Guava.