### PR TITLE
Use a NetworkBitmapClient as a wrapper for Picasso

### DIFF
--- a/app/src/main/java/com/artemzin/qualitymatters/ApplicationModule.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/ApplicationModule.java
@@ -5,6 +5,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 
+import com.artemzin.qualitymatters.models.QualityMattersImageLoader;
+import com.artemzin.qualitymatters.models.PicassoImageLoader;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jakewharton.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
@@ -48,5 +50,10 @@ public class ApplicationModule {
         return new Picasso.Builder(qualityMattersApp)
                 .downloader(new OkHttp3Downloader(okHttpClient))
                 .build();
+    }
+
+    @Provides @NonNull @Singleton
+    public QualityMattersImageLoader provideImageLoader(@NonNull Picasso picasso) {
+        return new PicassoImageLoader(picasso);
     }
 }

--- a/app/src/main/java/com/artemzin/qualitymatters/models/PicassoImageLoader.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/models/PicassoImageLoader.java
@@ -1,0 +1,21 @@
+package com.artemzin.qualitymatters.models;
+
+import android.support.annotation.NonNull;
+import android.widget.ImageView;
+
+import com.squareup.picasso.Picasso;
+
+public class PicassoImageLoader implements QualityMattersImageLoader {
+
+    @NonNull
+    private final Picasso picasso;
+
+    public PicassoImageLoader(@NonNull final Picasso picasso) {
+        this.picasso = picasso;
+    }
+
+    @Override
+    public void downloadInto(@NonNull String url, @NonNull ImageView imageView) {
+        picasso.load(url).fit().centerCrop().into(imageView);
+    }
+}

--- a/app/src/main/java/com/artemzin/qualitymatters/models/QualityMattersImageLoader.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/models/QualityMattersImageLoader.java
@@ -1,0 +1,8 @@
+package com.artemzin.qualitymatters.models;
+
+import android.support.annotation.NonNull;
+import android.widget.ImageView;
+
+public interface QualityMattersImageLoader {
+    void downloadInto(@NonNull String url, @NonNull ImageView imageView);
+}

--- a/app/src/main/java/com/artemzin/qualitymatters/ui/adapters/ItemViewHolder.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/ui/adapters/ItemViewHolder.java
@@ -5,15 +5,14 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
-
 import com.artemzin.qualitymatters.R;
 import com.artemzin.qualitymatters.api.entities.Item;
-import com.squareup.picasso.Picasso;
+import com.artemzin.qualitymatters.models.QualityMattersImageLoader;
 
 class ItemViewHolder extends RecyclerView.ViewHolder {
 
     @NonNull
-    private final Picasso picasso;
+    private final QualityMattersImageLoader imageLoader;
 
     private final ImageView imageView;
 
@@ -21,16 +20,16 @@ class ItemViewHolder extends RecyclerView.ViewHolder {
 
     private final TextView shortDescriptionTextView;
 
-    ItemViewHolder(@NonNull View itemView, @NonNull Picasso picasso) {
+    ItemViewHolder(@NonNull View itemView, @NonNull QualityMattersImageLoader imageLoader) {
         super(itemView);
-        this.picasso = picasso;
+        this.imageLoader = imageLoader;
         imageView = (ImageView) itemView.findViewById(R.id.list_item_image_view);
         titleTextView = (TextView) itemView.findViewById(R.id.list_item_title_text_view);
         shortDescriptionTextView = (TextView) itemView.findViewById(R.id.list_item_short_description_text_view);
     }
 
     public void bind(@NonNull Item item) {
-        picasso.load(item.imagePreviewUrl()).fit().centerCrop().into(imageView);
+        imageLoader.downloadInto(item.imagePreviewUrl(), imageView);
         titleTextView.setText(item.title());
         shortDescriptionTextView.setText(item.shortDescription());
     }

--- a/app/src/main/java/com/artemzin/qualitymatters/ui/adapters/ItemsAdapter.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/ui/adapters/ItemsAdapter.java
@@ -7,7 +7,7 @@ import android.view.ViewGroup;
 
 import com.artemzin.qualitymatters.R;
 import com.artemzin.qualitymatters.api.entities.Item;
-import com.squareup.picasso.Picasso;
+import com.artemzin.qualitymatters.models.QualityMattersImageLoader;
 
 import java.util.List;
 
@@ -20,14 +20,14 @@ public class ItemsAdapter extends RecyclerView.Adapter<ItemViewHolder> {
     private final LayoutInflater layoutInflater;
 
     @NonNull
-    private final Picasso picasso;
+    private final QualityMattersImageLoader imageLoader;
 
     @NonNull
     private List<Item> items = emptyList();
 
-    public ItemsAdapter(@NonNull LayoutInflater layoutInflater, @NonNull Picasso picasso) {
+    public ItemsAdapter(@NonNull LayoutInflater layoutInflater, @NonNull QualityMattersImageLoader imageLoader) {
         this.layoutInflater = layoutInflater;
-        this.picasso = picasso;
+        this.imageLoader = imageLoader;
     }
 
     @Override
@@ -42,7 +42,7 @@ public class ItemsAdapter extends RecyclerView.Adapter<ItemViewHolder> {
 
     @Override @NonNull
     public ItemViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        return new ItemViewHolder(layoutInflater.inflate(R.layout.list_item, parent, false), picasso);
+        return new ItemViewHolder(layoutInflater.inflate(R.layout.list_item, parent, false), imageLoader);
     }
 
     @Override

--- a/app/src/main/java/com/artemzin/qualitymatters/ui/fragments/ItemsFragment.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/ui/fragments/ItemsFragment.java
@@ -9,13 +9,16 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
 import com.artemzin.qualitymatters.ApplicationModule;
 import com.artemzin.qualitymatters.QualityMattersApp;
 import com.artemzin.qualitymatters.R;
 import com.artemzin.qualitymatters.api.entities.Item;
 import com.artemzin.qualitymatters.models.AnalyticsModel;
 import com.artemzin.qualitymatters.models.ItemsModel;
+import com.artemzin.qualitymatters.models.QualityMattersImageLoader;
 import com.artemzin.qualitymatters.performance.AnyThread;
 import com.artemzin.qualitymatters.performance.AsyncJobsObserver;
 import com.artemzin.qualitymatters.ui.adapters.ItemsAdapter;
@@ -23,19 +26,12 @@ import com.artemzin.qualitymatters.ui.adapters.VerticalSpaceItemDecoration;
 import com.artemzin.qualitymatters.ui.presenters.ItemsPresenter;
 import com.artemzin.qualitymatters.ui.presenters.ItemsPresenterConfiguration;
 import com.artemzin.qualitymatters.ui.views.ItemsView;
-import com.squareup.picasso.Picasso;
-
-import java.util.List;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import butterknife.Bind;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
 import dagger.Module;
 import dagger.Provides;
 import dagger.Subcomponent;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
 import rx.schedulers.Schedulers;
 
 import static android.support.v7.widget.LinearLayoutManager.VERTICAL;
@@ -62,7 +58,7 @@ public class ItemsFragment extends BaseFragment implements ItemsView {
     ItemsPresenter itemsPresenter;
 
     @Inject
-    Picasso picasso;
+    QualityMattersImageLoader networkBitmapClient;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -81,7 +77,7 @@ public class ItemsFragment extends BaseFragment implements ItemsView {
         ButterKnife.bind(this, view);
         contentUiRecyclerView.setLayoutManager(new LinearLayoutManager(getContext(), VERTICAL, false));
         contentUiRecyclerView.addItemDecoration(new VerticalSpaceItemDecoration((int) getResources().getDimension(R.dimen.list_item_vertical_space_between_items)));
-        itemsAdapter = new ItemsAdapter(getActivity().getLayoutInflater(), picasso);
+        itemsAdapter = new ItemsAdapter(getActivity().getLayoutInflater(), networkBitmapClient);
         contentUiRecyclerView.setAdapter(itemsAdapter);
         itemsPresenter.bindView(this);
         itemsPresenter.reloadData();

--- a/app/src/unitTests/java/com/artemzin/qualitymatters/models/PicassoImageLoaderTest.java
+++ b/app/src/unitTests/java/com/artemzin/qualitymatters/models/PicassoImageLoaderTest.java
@@ -1,0 +1,72 @@
+package com.artemzin.qualitymatters.models;
+
+import android.support.annotation.NonNull;
+import android.widget.ImageView;
+
+import com.artemzin.qualitymatters.QualityMattersRobolectricUnitTestRunner;
+import com.squareup.picasso.Picasso;
+import com.squareup.picasso.RequestCreator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(QualityMattersRobolectricUnitTestRunner.class)
+public class PicassoImageLoaderTest {
+
+    private static final String FAKE_URL = "http://fakeUrl.com";
+    
+    @SuppressWarnings("NullableProblems") // Initialized in @Before.
+    @NonNull
+    private ImageView imageView;
+
+    @SuppressWarnings("NullableProblems") // Initialized in @Before.
+    @NonNull
+    private Picasso picasso;
+
+    @SuppressWarnings("NullableProblems") // Initialized in @Before.
+    @NonNull
+    private PicassoImageLoader picassoBitmapClient;
+
+    @SuppressWarnings("NullableProblems") // Initialized in @Before.
+    @NonNull
+    private RequestCreator loadRequestCreator;
+
+    @SuppressWarnings("NullableProblems") // Initialized in @Before.
+    @NonNull
+    private RequestCreator fitRequestCreator;
+
+    @SuppressWarnings("NullableProblems") // Initialized in @Before.
+    @NonNull
+    private RequestCreator centerCropRequestCreator;
+
+    @Before
+    public void setUp() {
+        picasso = mock(Picasso.class);
+        imageView = mock(ImageView.class);
+
+        loadRequestCreator = mock(RequestCreator.class);
+        fitRequestCreator = mock(RequestCreator.class);
+        centerCropRequestCreator = mock(RequestCreator.class);
+
+        when(picasso.load(FAKE_URL)).thenReturn(loadRequestCreator);
+        when(loadRequestCreator.fit()).thenReturn(fitRequestCreator);
+        when(fitRequestCreator.centerCrop()).thenReturn(centerCropRequestCreator);
+
+        picassoBitmapClient = new PicassoImageLoader(picasso);
+    }
+
+    @Test
+    public void downloadInto_shouldLoadThenFitThenCenterCrop() {
+        picassoBitmapClient.downloadInto(FAKE_URL, imageView);
+
+        verify(picasso).load(FAKE_URL);
+        verify(loadRequestCreator).fit();
+        verify(fitRequestCreator).centerCrop();
+        verify(centerCropRequestCreator).into(imageView);
+    }
+}

--- a/app/src/unitTests/java/com/artemzin/qualitymatters/ui/adapters/ItemViewHolderTest.java
+++ b/app/src/unitTests/java/com/artemzin/qualitymatters/ui/adapters/ItemViewHolderTest.java
@@ -5,27 +5,22 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.artemzin.qualitymatters.QualityMattersRobolectricUnitTestRunner;
 import com.artemzin.qualitymatters.R;
 import com.artemzin.qualitymatters.api.entities.Item;
-import com.squareup.picasso.Picasso;
-import com.squareup.picasso.RequestCreator;
+import com.artemzin.qualitymatters.models.QualityMattersImageLoader;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(QualityMattersRobolectricUnitTestRunner.class)
 public class ItemViewHolderTest {
 
     @SuppressWarnings("NullableProblems") // Initialized in @Before.
     @NonNull
-    private Picasso picasso;
+    private QualityMattersImageLoader imageLoader;
 
     @SuppressWarnings("NullableProblems") // Initialized in @Before.
     @NonNull
@@ -53,13 +48,7 @@ public class ItemViewHolderTest {
 
     @Before
     public void beforeEachTest() {
-        picasso = mock(Picasso.class);
-
-        // Just mock the "Fluent API"…
-        RequestCreator requestCreator = mock(RequestCreator.class);
-        when(picasso.load(anyString())).thenReturn(requestCreator);
-        when(requestCreator.fit()).thenReturn(requestCreator);
-        when(requestCreator.centerCrop()).thenReturn(requestCreator);
+        imageLoader = mock(QualityMattersImageLoader.class);
 
         itemView = mock(View.class);
 
@@ -71,7 +60,7 @@ public class ItemViewHolderTest {
         when(itemView.findViewById(R.id.list_item_title_text_view)).thenReturn(titleTextView);
         when(itemView.findViewById(R.id.list_item_short_description_text_view)).thenReturn(shortDescriptionTextView);
 
-        itemViewHolder = new ItemViewHolder(itemView, picasso);
+        itemViewHolder = new ItemViewHolder(itemView, imageLoader);
 
         item = Item.builder()
                 .id("1")
@@ -83,20 +72,8 @@ public class ItemViewHolderTest {
 
     @Test
     public void bind_shouldLoadPreviewImage() {
-        RequestCreator loadRequestCreator = mock(RequestCreator.class);
-        RequestCreator fitRequestCreator = mock(RequestCreator.class);
-        RequestCreator centerCropRequestCreator = mock(RequestCreator.class);
-
-        when(picasso.load(item.imagePreviewUrl())).thenReturn(loadRequestCreator);
-        when(loadRequestCreator.fit()).thenReturn(fitRequestCreator);
-        when(fitRequestCreator.centerCrop()).thenReturn(centerCropRequestCreator);
-
         itemViewHolder.bind(item);
-
-        verify(picasso).load(item.imagePreviewUrl());
-        verify(loadRequestCreator).fit();
-        verify(fitRequestCreator).centerCrop();
-        verify(centerCropRequestCreator).into(imageView);
+        verify(imageLoader).downloadInto(item.imagePreviewUrl(), imageView);
     }
 
     @Test

--- a/app/src/unitTests/java/com/artemzin/qualitymatters/ui/adapters/ItemsAdapterTest.java
+++ b/app/src/unitTests/java/com/artemzin/qualitymatters/ui/adapters/ItemsAdapterTest.java
@@ -11,7 +11,7 @@ import android.widget.TextView;
 import com.artemzin.qualitymatters.QualityMattersRobolectricUnitTestRunner;
 import com.artemzin.qualitymatters.R;
 import com.artemzin.qualitymatters.api.entities.Item;
-import com.squareup.picasso.Picasso;
+import com.artemzin.qualitymatters.models.QualityMattersImageLoader;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -36,7 +36,7 @@ public class ItemsAdapterTest {
 
     @SuppressWarnings("NullableProblems") // Initialized in @Before.
     @NonNull
-    private Picasso picasso;
+    private QualityMattersImageLoader imageLoader;
 
     @SuppressWarnings("NullableProblems") // Initialized in @Before.
     @NonNull
@@ -45,8 +45,8 @@ public class ItemsAdapterTest {
     @Before
     public void beforeEachTest() {
         layoutInflater = mock(LayoutInflater.class);
-        picasso = mock(Picasso.class);
-        adapter = new ItemsAdapter(layoutInflater, picasso);
+        imageLoader = mock(QualityMattersImageLoader.class);
+        adapter = new ItemsAdapter(layoutInflater, imageLoader);
     }
 
     @Test


### PR DESCRIPTION
We should use a wrapper for Picasso instead of using it directly. With a wrapper we can easily switch to another ImageCaching client such as: Glide.