### PR TITLE
Update Yandex AppMetrica to v2.40

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,7 @@ ext.versions = [
         stetho                       : '1.3.0',
         leakCanary                   : '1.3.1',
         tinyDancer                   : '0.0.8',
-        yandexAppMetrica             : '2.30',
+        yandexAppMetrica             : '2.40',
         lynx                         : '1.6',
 
         junit                        : '4.12',


### PR DESCRIPTION
#### Changelog
##### Version 2.40

Released 28 March 2016
* Added the ability to send statistics using an API key that differs from the app's API key.
* The library's API LEVEL is 43. Change it in the AndroidManifest.xml file.