### PR TITLE
Update variables name

### DIFF
--- a/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModelImpl.java
+++ b/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModelImpl.java
@@ -20,7 +20,7 @@ import static android.view.Gravity.TOP;
 public class DeveloperSettingsModelImpl implements DeveloperSettingsModel {
 
     @NonNull
-    private final Application qualityMattersApp;
+    private final Application application;
 
     @NonNull
     private final DeveloperSettings developerSettings;
@@ -43,12 +43,12 @@ public class DeveloperSettingsModelImpl implements DeveloperSettingsModel {
     @NonNull
     private AtomicBoolean tinyDancerDisplayed = new AtomicBoolean();
 
-    public DeveloperSettingsModelImpl(@NonNull Application qualityMattersApp,
+    public DeveloperSettingsModelImpl(@NonNull Application application,
                                       @NonNull DeveloperSettings developerSettings,
                                       @NonNull HttpLoggingInterceptor httpLoggingInterceptor,
                                       @NonNull LeakCanaryProxy leakCanaryProxy,
                                       @NonNull Paperwork paperwork) {
-        this.qualityMattersApp = qualityMattersApp;
+        this.application = application;
         this.developerSettings = developerSettings;
         this.httpLoggingInterceptor = httpLoggingInterceptor;
         this.leakCanaryProxy = leakCanaryProxy;
@@ -117,7 +117,7 @@ public class DeveloperSettingsModelImpl implements DeveloperSettingsModel {
         // Stetho can not be enabled twice.
         if (stethoAlreadyEnabled.compareAndSet(false, true)) {
             if (isStethoEnabled()) {
-                Stetho.initializeWithDefaults(qualityMattersApp);
+                Stetho.initializeWithDefaults(application);
             }
         }
 
@@ -129,7 +129,7 @@ public class DeveloperSettingsModelImpl implements DeveloperSettingsModel {
         }
 
         if (isTinyDancerEnabled() && tinyDancerDisplayed.compareAndSet(false, true)) {
-            final DisplayMetrics displayMetrics = qualityMattersApp.getResources().getDisplayMetrics();
+            final DisplayMetrics displayMetrics = application.getResources().getDisplayMetrics();
 
             TinyDancer.create()
                     .redFlagPercentage(0.2f)
@@ -137,10 +137,10 @@ public class DeveloperSettingsModelImpl implements DeveloperSettingsModel {
                     .startingGravity(TOP | START)
                     .startingXPosition(displayMetrics.widthPixels / 10)
                     .startingYPosition(displayMetrics.heightPixels / 4)
-                    .show(qualityMattersApp);
+                    .show(application);
         } else if (tinyDancerDisplayed.compareAndSet(true, false)) {
             try {
-                TinyDancer.hide(qualityMattersApp);
+                TinyDancer.hide(application);
             } catch (Exception e) {
                 // In some cases TinyDancer can not be hidden without exception: for example when you start it first time on Android 6.
                 Timber.e(e, "Can not hide TinyDancer");

--- a/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModule.java
+++ b/app/src/debug/java/com/artemzin/qualitymatters/developer_settings/DeveloperSettingsModule.java
@@ -40,34 +40,34 @@ public class DeveloperSettingsModule {
     @Provides
     @NonNull
     @Singleton
-    public DeveloperSettings provideDeveloperSettings(@NonNull Application qualityMattersApp) {
-        return new DeveloperSettings(qualityMattersApp.getSharedPreferences("developer_settings", MODE_PRIVATE));
+    public DeveloperSettings provideDeveloperSettings(@NonNull Application application) {
+        return new DeveloperSettings(application.getSharedPreferences("developer_settings", MODE_PRIVATE));
     }
 
     @Provides
     @NonNull
     @Singleton
-    public LeakCanaryProxy provideLeakCanaryProxy(@NonNull Application qualityMattersApp) {
-        return new LeakCanaryProxyImpl(qualityMattersApp);
+    public LeakCanaryProxy provideLeakCanaryProxy(@NonNull Application application) {
+        return new LeakCanaryProxyImpl(application);
     }
 
     @Provides
     @NonNull
     @Singleton
-    public Paperwork providePaperwork(@NonNull Application qualityMattersApp) {
-        return new Paperwork(qualityMattersApp);
+    public Paperwork providePaperwork(@NonNull Application application) {
+        return new Paperwork(application);
     }
 
     // We will use this concrete type for debug code, but main code will see only DeveloperSettingsModel interface.
     @Provides
     @NonNull
     @Singleton
-    public DeveloperSettingsModelImpl provideDeveloperSettingsModelImpl(@NonNull Application qualityMattersApp,
+    public DeveloperSettingsModelImpl provideDeveloperSettingsModelImpl(@NonNull Application application,
                                                                         @NonNull DeveloperSettings developerSettings,
                                                                         @NonNull HttpLoggingInterceptor httpLoggingInterceptor,
                                                                         @NonNull LeakCanaryProxy leakCanaryProxy,
                                                                         @NonNull Paperwork paperwork) {
-        return new DeveloperSettingsModelImpl(qualityMattersApp, developerSettings, httpLoggingInterceptor, leakCanaryProxy, paperwork);
+        return new DeveloperSettingsModelImpl(application, developerSettings, httpLoggingInterceptor, leakCanaryProxy, paperwork);
     }
 
     @Provides

--- a/app/src/main/java/com/artemzin/qualitymatters/ApplicationModule.java
+++ b/app/src/main/java/com/artemzin/qualitymatters/ApplicationModule.java
@@ -24,15 +24,15 @@ public class ApplicationModule {
     public static final String MAIN_THREAD_HANDLER = "main_thread_handler";
 
     @NonNull
-    private final Application qualityMattersApp;
+    private final Application application;
 
-    public ApplicationModule(@NonNull Application qualityMattersApp) {
-        this.qualityMattersApp = qualityMattersApp;
+    public ApplicationModule(@NonNull Application application) {
+        this.application = application;
     }
 
     @Provides @NonNull @Singleton
     public Application provideQualityMattersApp() {
-        return qualityMattersApp;
+        return application;
     }
 
     @Provides @NonNull @Singleton


### PR DESCRIPTION
We now provide Application instance instead of QualityMatterApplication but we still use qualityMatterApplication as a variable name. This Pr is to fix it.