### PR TITLE
Disable AndroidDevMetrics during unit tests

### DIFF
--- a/app/src/integrationTests/java/com/artemzin/qualitymatters/QualityMattersIntegrationTestApp.java
+++ b/app/src/integrationTests/java/com/artemzin/qualitymatters/QualityMattersIntegrationTestApp.java
@@ -3,6 +3,8 @@ package com.artemzin.qualitymatters;
 import android.app.Application;
 import android.support.annotation.NonNull;
 
+import com.artemzin.qualitymatters.developer_settings.DevMetricsProxy;
+import com.artemzin.qualitymatters.developer_settings.DeveloperSettingsModule;
 import com.artemzin.qualitymatters.models.AnalyticsModel;
 import com.artemzin.qualitymatters.models.ModelsModule;
 
@@ -19,6 +21,14 @@ public class QualityMattersIntegrationTestApp extends QualityMattersApp {
                     @Override
                     public AnalyticsModel provideAnalyticsModel(@NonNull Application app) {
                         return mock(AnalyticsModel.class); // We don't need real analytics in integration tests.
+                    }
+                })
+                .developerSettingsModule(new DeveloperSettingsModule() {
+                    @NonNull
+                    public DevMetricsProxy provideDevMetricsProxy(@NonNull Application application) {
+                        return () -> {
+                            //No Op
+                        };
                     }
                 });
     }

--- a/app/src/unitTests/java/com/artemzin/qualitymatters/QualityMattersUnitTestApp.java
+++ b/app/src/unitTests/java/com/artemzin/qualitymatters/QualityMattersUnitTestApp.java
@@ -3,6 +3,8 @@ package com.artemzin.qualitymatters;
 import android.app.Application;
 import android.support.annotation.NonNull;
 
+import com.artemzin.qualitymatters.developer_settings.DevMetricsProxy;
+import com.artemzin.qualitymatters.developer_settings.DeveloperSettingsModule;
 import com.artemzin.qualitymatters.models.AnalyticsModel;
 import com.artemzin.qualitymatters.models.ModelsModule;
 
@@ -19,6 +21,14 @@ public class QualityMattersUnitTestApp extends QualityMattersApp {
                     @Override
                     public AnalyticsModel provideAnalyticsModel(@NonNull Application app) {
                         return mock(AnalyticsModel.class); // We don't need real analytics in Unit tests.
+                    }
+                })
+                .developerSettingsModule(new DeveloperSettingsModule() {
+                    @NonNull
+                    public DevMetricsProxy provideDevMetricsProxy(@NonNull Application application) {
+                        return () -> {
+                            //No Op
+                        };
                     }
                 });
     }


### PR DESCRIPTION
This fixes the issue I've been having with Android Studio not running
Roboelectric tests. All the tests pass locally on my system. Thoughts @artem-zinnatullin? 

@vanniktech Please tell me if this fixes your issue as well!