### PR TITLE
Switch FindBugs to use HTML reports

### DIFF
--- a/code_quality_tools/quality.gradle
+++ b/code_quality_tools/quality.gradle
@@ -20,10 +20,8 @@ task findbugs(type: FindBugs) {
     reportLevel = 'low' // Report even low priority problems.
 
     reports {
-        xml {
-            enabled = true
-            withMessages = true
-        }
+        html.enabled = true
+        xml.enabled = false
     }
 
     classes = files("${project.projectDir}/build/intermediates/classes")


### PR DESCRIPTION
FindBugs XML reports are impossible to read

IMO this HTML report is way clearer: 
![screencapture-file-users-pieper-androidstudioprojects-qualitymatters-app-build-reports-findbugs-findbugs-html-1461964050447](https://cloud.githubusercontent.com/assets/1526881/14930043/1611b102-0e2f-11e6-8fa5-d3066db3cfed.png)
