### PR TITLE
Integrate gradle versions plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'hu.supercluster.paperwork'
 apply from: '../code_quality_tools/jacoco.gradle'
 apply plugin: 'com.frogermcs.androiddevmetrics'
 apply from: '../code_quality_tools/quality.gradle'
+apply plugin: 'com.github.ben-manes.versions'
 
 paperwork {
     set = [

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ buildscript {
 
         // Method count plugin for android projects
         classpath gradlePlugins.dexcount
+
+        // Check latest version of dependencies, task: dependencyUpdates
+        classpath gradlePlugins.versions
     }
 
     // Part of workaround for Lint + Retrolambda.
@@ -84,6 +87,8 @@ subprojects {
         checkTask.dependsOn('pmd')
         checkTask.dependsOn('findbugs')
         checkTask.dependsOn('checkstyle')
+
+        dependencyUpdates.outputDir = new File("${projectDir}/build/reports/versions")
 
         // Log instrumentation tests results.
         tasks.withType(com.android.build.gradle.internal.tasks.AndroidTestTask) { task ->

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,6 +17,7 @@ ext.versions = [
         errorProneVersion            : '0.0.8',
         errorProneCoreVersion        : '2.0.9',
         dexcountPlugin               : '0.5.4',
+        versionsGradlePlugin         : '0.13.0',
 
         dagger                       : '2.4',
 
@@ -58,6 +59,7 @@ ext.gradlePlugins = [
         androidDevMetrics: "com.frogermcs.androiddevmetrics:androiddevmetrics-plugin:$versions.androidDevMetricsGradlePlugin",
         errorProne       : "net.ltgt.gradle:gradle-errorprone-plugin:$versions.errorProneVersion",
         dexcount         : "com.getkeepsafe.dexcount:dexcount-gradle-plugin:$versions.dexcountPlugin",
+        versions         : "com.github.ben-manes:gradle-versions-plugin:$versions.versionsGradlePlugin",
 ]
 
 ext.libraries = [


### PR DESCRIPTION
Very useful plugin for update dependencies to latest versions.
https://github.com/ben-manes/gradle-versions-plugin

Keep dependencies latest stable - more quality - less bugs.

Current report:
```
------------------------------------------------------------
:app Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.android.support:support-annotations:23.1.1
 - com.android.support.test:rules:0.5
 - com.android.support.test:runner:0.5
 - com.facebook.stetho:stetho:1.3.1
 - com.facebook.stetho:stetho-okhttp3:1.3.1
 - com.frogermcs.androiddevmetrics:androiddevmetrics-runtime:0.4
 - com.frogermcs.androiddevmetrics:androiddevmetrics-runtime-noop:0.4
 - com.github.pedrovgs:lynx:1.6
 - com.google.code.findbugs:findbugs:3.0.1
 - com.google.dagger:dagger:2.4
 - com.google.dagger:dagger-compiler:2.4
 - com.jakewharton:butterknife:8.0.1
 - com.jakewharton:butterknife-compiler:8.0.1
 - com.jakewharton:process-phoenix:1.0.2
 - com.jakewharton.picasso:picasso2-okhttp3-downloader:1.0.2
 - com.jakewharton.timber:timber:4.1.2
 - com.squareup.okhttp3:logging-interceptor:3.2.0
 - com.squareup.okhttp3:mockwebserver:3.2.0
 - com.squareup.okhttp3:okhttp:3.2.0
 - com.squareup.picasso:picasso:2.5.2
 - hu.supercluster:paperwork:1.2.7
 - io.reactivex:rxjava:1.1.5
 - junit:junit:4.12
 - net.sourceforge.pmd:pmd-java:5.4.1
 - nl.littlerobots.rxlint:rxlint:1.0
 - org.jacoco:org.jacoco.agent:0.7.6.201602180812

The following dependencies exceed the version found at the milestone revision level:
 - com.squareup.leakcanary:leakcanary-android [1.4-beta2 <- 1.3.1]

The following dependencies have later milestone versions:
 - com.android.support:appcompat-v7 [23.1.1 -> 24.0.0-alpha2]
 - com.android.support:cardview-v7 [23.1.1 -> 24.0.0-alpha2]
 - com.android.support:design [23.1.1 -> 24.0.0-alpha2]
 - com.android.support:recyclerview-v7 [23.1.1 -> 24.0.0-alpha2]
 - com.android.support:support-v4 [23.1.1 -> 24.0.0-alpha2]
 - com.android.support.test.espresso:espresso-contrib [2.2.1 -> 2.2.2]
 - com.android.support.test.espresso:espresso-core [2.2.1 -> 2.2.2]
 - com.fasterxml.jackson.core:jackson-databind [2.6.3 -> 2.7.4]
 - com.github.brianPlummer:tinydancer [0.0.8 -> 0.0.9]
 - com.google.auto.value:auto-value [1.2-rc1 -> 1.2]
 - com.puppycrawl.tools:checkstyle [6.16.1 -> 6.18]
 - com.squareup.retrofit2:adapter-rxjava [2.0.0-beta4 -> 2.0.2]
 - com.squareup.retrofit2:converter-jackson [2.0.0-beta4 -> 2.0.2]
 - com.squareup.retrofit2:retrofit [2.0.0-beta4 -> 2.0.2]
 - com.yandex.android:mobmetricalib [2.40 -> 2.41]
 - net.orfjackal.retrolambda:retrolambda [2.1.0 -> 2.3.0]
 - nl.jqno.equalsverifier:equalsverifier [1.7.5 -> 2.0.2]
 - org.aspectj:aspectjrt [1.8.8 -> 1.8.9]
 - org.assertj:assertj-core [2.4.0 -> 3.4.1]
 - org.jacoco:org.jacoco.agent [0.7.1.201405082137 -> 0.7.6.201602180812]
 - org.mockito:mockito-core [1.10.19 -> 2.0.52-beta]
 - org.robolectric:robolectric [3.0 -> 3.1-rc1]
```