### PR TITLE
208 update rxjava to rxjava2, also target sdk and build tools for latest stable Android Studio

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,7 +116,6 @@ dependencies {
     annotationProcessor libraries.daggerCompiler
 
     compile libraries.rxJava
-    releaseCompile libraries.rxJavaProguardRules
     compile libraries.rxLint
 
     compile libraries.okHttp

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,11 +3,11 @@ ext.versions = [
         name                         : '1.0',
 
         minSdk                       : 16,
-        targetSdk                    : 23,
-        compileSdk                   : 23,
-        buildTools                   : '23.0.3',
+        targetSdk                    : 25,
+        compileSdk                   : 25,
+        buildTools                   : '25.0.3',
 
-        androidGradlePlugin          : '2.2.1',
+        androidGradlePlugin          : '2.3.3',
         retrolambdaGradlePlugin      : '3.2.5',
         lombokGradlePlugin           : '0.2.3.a2',
         paperworkGradlePlugin        : '1.2.7',
@@ -21,9 +21,8 @@ ext.versions = [
 
         dagger                       : '2.6',
 
-        rxJava                       : '1.1.8',
-        rxJavaProguardRules          : '1.1.8.0',
-        rxLint                       : '1.0',
+        rxJava                       : '2.1.5',
+        rxLint                       : '1.6',
         supportLibs                  : '23.1.1',
         okHttp                       : '3.2.0',
         retrofit                     : '2.0.0-beta4',
@@ -68,8 +67,7 @@ ext.libraries = [
         dagger                  : "com.google.dagger:dagger:$versions.dagger",
         daggerCompiler          : "com.google.dagger:dagger-compiler:$versions.dagger",
 
-        rxJava                  : "io.reactivex:rxjava:$versions.rxJava",
-        rxJavaProguardRules     : "com.artemzin.rxjava:proguard-rules:$versions.rxJavaProguardRules",
+        rxJava                  : "io.reactivex.rxjava2:rxjava:$versions.rxJava",
         rxLint                  : "nl.littlerobots.rxlint:rxlint:$versions.rxLint",
 
         okHttp                  : "com.squareup.okhttp3:okhttp:$versions.okHttp",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 13 19:11:10 CEST 2016
+#Sat Oct 21 14:56:39 AEDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Removed  : rxJavaProguardRules   as per comment on that repo that it's not required for RxJava 2