### PR TITLE
Manually install Android SDK, disable UI tests, build tools 23.0.3 → 26.0.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,27 @@
 # Disabling sudo moves build to the Container Based Infrastructure on Travis CI
 sudo: false
 
-language: android
+language: java
 jdk: oraclejdk8
-
-android:
-  components:
-    - platform-tools
-    - tools
-    - android-23
-    - build-tools-23.0.3
-    - extra-android-m2repository
-    - extra-android-support
-    - sys-img-armeabi-v7a-android-18
 
 before_install:
   - pip install --user codecov
-
-before_script:
-  - echo no | android create avd --force -n test -t android-18 --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82
+  - export ANDROID_HOME="$HOME"/android-sdk
+  - mkdir -p "$ANDROID_HOME"
+  - export ANDROID_SDK_FILE_NAME=sdk-tools-darwin-3859397.zip
+  - curl --fail https://dl.google.com/android/repository/$ANDROID_SDK_FILE_NAME --silent --location --output $ANDROID_SDK_FILE_NAME
+  - unzip -qq $ANDROID_SDK_FILE_NAME -d "$ANDROID_HOME"
+  - rm $ANDROID_SDK_FILE_NAME
+  - export ANDROID_SDK_INSTALL_COMPONENT="echo \"y\" | \"$ANDROID_HOME\"/tools/bin/sdkmanager > /dev/null"
+  - eval $ANDROID_SDK_INSTALL_COMPONENT '"tools"'
+  - eval $ANDROID_SDK_INSTALL_COMPONENT '"platform-tools"'
+  - eval $ANDROID_SDK_INSTALL_COMPONENT '"build-tools;26.0.2"'
+  - eval $ANDROID_SDK_INSTALL_COMPONENT '"platforms;android-23"'
+  - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;android;m2repository"'
+  - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;google;m2repository"'
 
 script:
-  - bash build.sh
+  - ./build.sh
   
 after_success:
   - codecov

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,8 @@ set -xe
 PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # This will: compile the project, run lint, run tests under JVM, package apk, check the code quality and run tests on the device/emulator.
-"$PROJECT_DIR"/gradlew --no-daemon --info clean
-"$PROJECT_DIR"/gradlew --no-daemon --info build -PdisablePreDex -PwithDexcount -Dscan
-"$PROJECT_DIR"/gradlew --no-daemon --info connectedAndroidTest -PdisablePreDex -PwithDexcount
+"$PROJECT_DIR"/gradlew --no-daemon --info clean build -PdisablePreDex -PwithDexcount -Dscan
+
+# Disable instrumentation tests for now, Travis is too flaky with Android Emulator.
+# See https://github.com/artem-zinnatullin/qualitymatters/issues/220
+# "$PROJECT_DIR"/gradlew --no-daemon --info connectedAndroidTest -PdisablePreDex -PwithDexcount

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ ext.versions = [
         minSdk                       : 16,
         targetSdk                    : 23,
         compileSdk                   : 23,
-        buildTools                   : '23.0.3',
+        buildTools                   : '26.0.2',
 
         androidGradlePlugin          : '2.2.1',
         retrolambdaGradlePlugin      : '3.2.5',


### PR DESCRIPTION
- Default way of SDK installation overflows Travis log limit, see https://github.com/pushtorefresh/storio/pull/824
- Temporary disable UI tests on CI see #220
- Didn't update versions of Android SDK components except build-tools (see below) to minimize scope of PR, will do in a separate PR

Had to update build-tools version, otherwise build crashed (I suppose `language: android` took care of [system dependencies for old version of aapt](https://stackoverflow.com/questions/22701405/aapt-ioexception-error-2-no-such-file-or-directory-why-cant-i-build-my-grad)):

```console
:app:mergeDebugResourcesjava.io.IOException: Cannot run program "/home/travis/android-sdk/build-tools/23.0.3/aapt": error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at com.android.builder.png.AaptProcess$Builder.start(AaptProcess.java:167)
	at com.android.builder.png.QueuedCruncher$1.creation(QueuedCruncher.java:116)
	at com.android.builder.tasks.WorkQueue.run(WorkQueue.java:203)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: error=2, No such file or directory
	at java.lang.UNIXProcess.forkAndExec(Native Method)
	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
	... 4 more
```

@vanniktech PTAL