### PR TITLE
Download Linux Android SDK on Travis instead of macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - pip install --user codecov
   - export ANDROID_HOME="$HOME"/android-sdk
   - mkdir -p "$ANDROID_HOME"
-  - export ANDROID_SDK_FILE_NAME=sdk-tools-darwin-3859397.zip
+  - export ANDROID_SDK_FILE_NAME=sdk-tools-linux-3859397.zip
   - curl --fail https://dl.google.com/android/repository/$ANDROID_SDK_FILE_NAME --silent --location --output $ANDROID_SDK_FILE_NAME
   - unzip -qq $ANDROID_SDK_FILE_NAME -d "$ANDROID_HOME"
   - rm $ANDROID_SDK_FILE_NAME


### PR DESCRIPTION
This is facepalm.jpg kindly noticed here https://github.com/uber/okbuck/pull/547#discussion_r147523094, apparently part of SDK tools we use for build are crossplatform enough to work on Linux lol