### PR TITLE
Override default Travis install step to avoid unnecessary './gradlew assemble'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;google;m2repository"'
 
 install:
-  - echo 'Just overriding standard Travis install procedure to avoid unnecessary work.'
+  - echo "Override default Travis install step to avoid unnecessary './gradlew assemble'."
 
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_install:
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;android;m2repository"'
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;google;m2repository"'
 
+install:
+  - echo 'Just overriding standard Travis install procedure to avoid unnecessary work.'
+
 script:
   - ./build.sh
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;google;m2repository"'
 
 install:
-  - echo "Override default Travis install step to avoid unnecessary './gradlew assemble'."
+  - echo "Overriding default Travis install step to avoid unnecessary './gradlew assemble'."
 
 script:
   - ./build.sh


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/8667 for details, this will speedup all CI builds!