### PR TITLE
Executes the builds much more quickly by Gradle Daemon

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ set -xe
 PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # This will: compile the project, run lint, run tests under JVM, package apk, check the code quality and run tests on the device/emulator.
-"$PROJECT_DIR"/gradlew --no-daemon --info clean build -PdisablePreDex -PwithDexcount -Dscan
+"$PROJECT_DIR"/gradlew --daemon --info clean build -PdisablePreDex -PwithDexcount -Dscan
 
 # Disable instrumentation tests for now, Travis is too flaky with Android Emulator.
 # See https://github.com/artem-zinnatullin/qualitymatters/issues/220
-# "$PROJECT_DIR"/gradlew --no-daemon --info connectedAndroidTest -PdisablePreDex -PwithDexcount
+# "$PROJECT_DIR"/gradlew --daemon --info connectedAndroidTest -PdisablePreDex -PwithDexcount


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
